### PR TITLE
release/1.04

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,20 @@
+name: Build
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        buildable: [zip, xelatex, lualatex, pdflatex]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@v2
+        with:
+          github-token: ${{ github.token }}
+      - run: nix build .#${{ matrix.buildable }}
+      - uses: actions/upload-artifact@v3
+        if: ${{ matrix.buildable == 'zip' }}
+        with:
+          name: listlbls.zip
+          path: result/listlbls-*.zip

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@v2
         with:
           github-token: ${{ github.token }}
-      - run: nix build .#${{ matrix.buildable }}
+      - run: nix build .#${{ matrix.buildable }} -L
       - run: cp result/*.zip .
         if: ${{ matrix.buildable == 'zip' }}
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,8 +15,20 @@ jobs:
       - run: nix build .#${{ matrix.buildable }} -L
       - run: cp result/*.zip .
         if: ${{ matrix.buildable == 'zip' }}
+      - run: cp result/{share/doc/latex/listlbls/listlbls.pdf,tex/latex/listlbls/listlbls.sty} .
+        if: ${{ matrix.buildable == 'xelatex' }}
       - uses: actions/upload-artifact@v3
         if: ${{ matrix.buildable == 'zip' }}
         with:
           name: listlbls.zip
           path: listlbls-*.zip
+      - uses: actions/upload-artifact@v3
+        if: ${{ matrix.buildable == 'xelatex' }}
+        with:
+          name: listlbls.pdf
+          path: listlbls.pdf
+      - uses: actions/upload-artifact@v3
+        if: ${{ matrix.buildable == 'xelatex' }}
+        with:
+          name: listlbls.sty
+          path: listlbls.sty

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,8 +13,10 @@ jobs:
         with:
           github-token: ${{ github.token }}
       - run: nix build .#${{ matrix.buildable }}
+      - run: cp result/*.zip .
+        if: ${{ matrix.buildable == 'zip' }}
       - uses: actions/upload-artifact@v3
         if: ${{ matrix.buildable == 'zip' }}
         with:
           name: listlbls.zip
-          path: result/listlbls-*.zip
+          path: listlbls-*.zip

--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,12 @@ README.txt: $(NAME).pdf
 README.md: $(NAME).pdf
 
 $(NAME).pdf: $(NAME).dtx
-	$(LATEX) -shell-escape -recorder -interaction=batchmode $(NAME).dtx
+	$(LATEX) -shell-escape -recorder $(NAME).dtx
 	if [ -f $(NAME).glo ]; then makeindex -q -s gglo.ist -o $(NAME).gls $(NAME).glo; fi
 	if [ -f $(NAME).idx ]; then makeindex -q -s gind.ist -o $(NAME).ind $(NAME).idx; fi
-	$(LATEX) -shell-escape -recorder -interaction=batchmode $(NAME).dtx
-	$(LATEX) -shell-escape -recorder -interaction=batchmode $(NAME).dtx
-	$(LATEX) -shell-escape -recorder -interaction=batchmode $(NAME).dtx
+	$(LATEX) -shell-escape -recorder -interaction=scrollmode $(NAME).dtx
+	$(LATEX) -shell-escape -recorder -interaction=scrollmode $(NAME).dtx
+	$(LATEX) -shell-escape -recorder -interaction=scrollmode $(NAME).dtx
 
 clean:
 	rm -f *.fls

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
-NAME  = listlbls
-SHELL = bash
-PWD   = $(shell pwd)
-TEMP := $(shell mktemp -d)
-TDIR  = $(TEMP)/$(NAME)
-VERS  = $(shell ltxfileinfo -v $(NAME).dtx)
-LOCAL = $(shell kpsewhich --var-value TEXMFLOCAL)
-UTREE = $(shell kpsewhich --var-value TEXMFHOME)
+NAME    = listlbls
+SHELL   = bash
+PWD     = $(shell pwd)
+TEMP   := $(shell mktemp -d)
+TDIR    = $(TEMP)/$(NAME)
+VERS    = $(shell ltxfileinfo -v $(NAME).dtx)
+LOCAL   = $(shell kpsewhich --var-value TEXMFLOCAL)
+UTREE   = $(shell kpsewhich --var-value TEXMFHOME)
+PREFIX ?= $(LOCAL)
+LATEX   = xelatex
+SUDO    = sudo
 
 all:	$(NAME).pdf README.md README clean
 
@@ -17,11 +20,12 @@ README.txt: $(NAME).pdf
 README.md: $(NAME).pdf
 
 $(NAME).pdf: $(NAME).dtx
-	xelatex -shell-escape -recorder -interaction=batchmode $(NAME).dtx >/dev/null
+	$(LATEX) -shell-escape -recorder -interaction=batchmode $(NAME).dtx
 	if [ -f $(NAME).glo ]; then makeindex -q -s gglo.ist -o $(NAME).gls $(NAME).glo; fi
 	if [ -f $(NAME).idx ]; then makeindex -q -s gind.ist -o $(NAME).ind $(NAME).idx; fi
-	xelatex -shell-escape -recorder -interaction=nonstopmode $(NAME).dtx > /dev/null
-	xelatex -shell-escape -recorder -interaction=nonstopmode $(NAME).dtx > /dev/null
+	$(LATEX) -shell-escape -recorder -interaction=batchmode $(NAME).dtx
+	$(LATEX) -shell-escape -recorder -interaction=batchmode $(NAME).dtx
+	$(LATEX) -shell-escape -recorder -interaction=batchmode $(NAME).dtx
 
 clean:
 	rm -f *.fls
@@ -31,16 +35,13 @@ distclean: clean
 	rm -f $(NAME).{pdf,sty} README{,.{md,txt}}
 
 inst: all
-	mkdir -p $(UTREE)/{tex,source,doc}/latex/$(NAME)
-	cp $(NAME).dtx $(UTREE)/source/latex/$(NAME)
-	cp $(NAME).sty $(UTREE)/tex/latex/$(NAME)
-	cp $(NAME).pdf $(UTREE)/doc/latex/$(NAME)
+	$(MAKE) install PREFIX=$(UTREE) SUDO=""
 
 install: all
-	sudo mkdir -p $(LOCAL)/{tex,source,doc}/latex/$(NAME)
-	sudo cp $(NAME).dtx $(LOCAL)/source/latex/$(NAME)
-	sudo cp $(NAME).sty $(LOCAL)/tex/latex/$(NAME)
-	sudo cp $(NAME).pdf $(LOCAL)/doc/latex/$(NAME)
+	$(SUDO) mkdir -p $(PREFIX)/{tex,source,doc}/latex/$(NAME)
+	$(SUDO) cp $(NAME).dtx $(PREFIX)/source/latex/$(NAME)
+	$(SUDO) cp $(NAME).sty $(PREFIX)/tex/latex/$(NAME)
+	$(SUDO) cp $(NAME).pdf $(PREFIX)/doc/latex/$(NAME)
 
 zip: all
 	mkdir $(TDIR)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ PREFIX ?= $(LOCAL)
 LATEX   = xelatex
 SUDO    = sudo
 
-all:	$(NAME).pdf README.md README clean
+all: $(NAME).pdf README.md README
+	$(MAKE) clean
 
 README: README.txt
 	cp README.txt README

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1684698729,
+        "narHash": "sha256-eFX+g0JNHYDuoGq3XvT+360UDIzRGFWcHh0il6rGz7g=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9356eead97d8d16956b0226d78f76bd66e06cb60",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684698729,
-        "narHash": "sha256-eFX+g0JNHYDuoGq3XvT+360UDIzRGFWcHh0il6rGz7g=",
+        "lastModified": 1684911969,
+        "narHash": "sha256-j2tz1P2rA3d1WYHk8+1WbYDIJO33BqW1EfQSvi+/O8s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9356eead97d8d16956b0226d78f76bd66e06cb60",
+        "rev": "87f9156865ab09e3bde39aadb4131ae364ae704e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -16,9 +16,46 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1682879489,
+        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1683560683,
+        "narHash": "sha256-XAygPMN5Xnk/W2c1aW0jyEa6lfMDZWlQgiNtmHXytPc=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "006c75898cf814ef9497252b022e91c946ba8e17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "parts": "parts"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,94 @@
+{
+  inputs.nixpkgs.url = "github:nixos/nixpkgs?ref=nixpkgs-unstable";
+
+  outputs = {
+    self,
+    nixpkgs,
+    ...
+  }: {
+    formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.alejandra;
+
+    packages.x86_64-linux = let
+      version = "1.04pre";
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+      tl = pkgs.texlive.combine {
+        inherit
+          (pkgs.texlive)
+          scheme-minimal
+          collection-luatex
+          babel-english
+          caption
+          dtxdescribe
+          etoolbox
+          fancyvrb
+          geometry
+          graphics
+          hypdoc
+          hyperref
+          infwarerr
+          kvoptions
+          latex-bin
+          microtype
+          newfloat
+          pdftexcmds
+          pict2e
+          tools
+          translations
+          xcolor
+          xetex
+          xstring
+          ;
+      };
+      inherit (pkgs) stdenvNoCC;
+      builder = engine:
+        stdenvNoCC.mkDerivation {
+          pname = "listllbls";
+          version = "${version}-${engine}";
+
+          src = "${self}";
+
+          nativeBuildInputs = [tl];
+
+          makeFlags = ["PREFIX=$(out)" "LATEX=${engine}" "SUDO="];
+
+          configurePhase = ''
+            export TEMP=$(pwd)
+            export HOME=$(pwd)
+          '';
+        };
+    in {
+      inherit tl;
+
+      xelatex = builder "xelatex";
+      lualatex = builder "lualatex";
+      pdflatex = builder "pdflatex";
+
+      zip = stdenvNoCC.mkDerivation {
+        pname = "listlbls";
+        inherit version;
+
+        src = "${self}";
+
+        nativeBuildInputs = [pkgs.zip tl];
+
+        makeFlags = ["zip" "VERS=$(version)"];
+
+        installPhase = ''
+          mkdir $out
+          install --mode 444 $pname-$version.zip $out/$pname-$version.zip
+        '';
+      };
+    };
+
+    devShells.x86_64-linux.default = let
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+      inherit (self.packages.x86_64-linux) tl;
+    in
+      pkgs.mkShellNoCC {
+        packages = builtins.attrValues {
+          inherit (pkgs) gnumake;
+          inherit tl;
+        };
+      };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
 
         devShells.default = pkgs.mkShellNoCC {
           packages = builtins.attrValues {
-            inherit (pkgs) gnumake;
+            inherit (pkgs) gnumake texlab nil;
             inherit (self'.packages) texCombined;
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -1,94 +1,100 @@
 {
   inputs.nixpkgs.url = "github:nixos/nixpkgs?ref=nixpkgs-unstable";
+  inputs.parts.url = "github:hercules-ci/flake-parts";
 
-  outputs = {
-    self,
-    nixpkgs,
-    ...
-  }: {
-    formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.alejandra;
+  outputs = {parts, ...} @ inputs:
+    parts.lib.mkFlake {inherit inputs;} {
+      systems = ["x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin"];
 
-    packages.x86_64-linux = let
-      version = "1.04pre";
-      pkgs = nixpkgs.legacyPackages.x86_64-linux;
-      tl = pkgs.texlive.combine {
-        inherit
-          (pkgs.texlive)
-          scheme-minimal
-          collection-luatex
-          babel-english
-          caption
-          dtxdescribe
-          etoolbox
-          fancyvrb
-          geometry
-          graphics
-          hypdoc
-          hyperref
-          infwarerr
-          kvoptions
-          latex-bin
-          microtype
-          newfloat
-          pdftexcmds
-          pict2e
-          tools
-          translations
-          xcolor
-          xetex
-          xstring
-          ;
-      };
-      inherit (pkgs) stdenvNoCC;
-      builder = engine:
-        stdenvNoCC.mkDerivation {
-          pname = "listllbls";
-          version = "${version}-${engine}";
+      perSystem = {
+        self,
+        inputs',
+        self',
+        pkgs,
+        ...
+      }: {
+        formatter = pkgs.alejandra;
 
-          src = "${self}";
+        packages = let
+          version = "1.04pre";
+          tl = pkgs.texlive.combine {
+            inherit
+              (pkgs.texlive)
+              scheme-minimal
+              collection-luatex
+              babel-english
+              caption
+              dtxdescribe
+              etoolbox
+              fancyvrb
+              geometry
+              graphics
+              hypdoc
+              hyperref
+              infwarerr
+              kvoptions
+              latex-bin
+              microtype
+              newfloat
+              pdftexcmds
+              pict2e
+              tools
+              translations
+              xcolor
+              xetex
+              xstring
+              ;
+          };
+          inherit (pkgs) stdenvNoCC;
+          builder = engine:
+            stdenvNoCC.mkDerivation {
+              pname = "listllbls";
+              version = "${version}-${engine}";
 
-          nativeBuildInputs = [tl];
+              src = "${self}";
 
-          makeFlags = ["PREFIX=$(out)" "LATEX=${engine}" "SUDO="];
+              nativeBuildInputs = [tl];
 
-          configurePhase = ''
-            export TEMP=$(pwd)
-            export HOME=$(pwd)
-          '';
+              makeFlags = ["PREFIX=$(out)" "LATEX=${engine}" "SUDO="];
+
+              configurePhase = ''
+                export TEMP=$(pwd)
+                export HOME=$(pwd)
+              '';
+            };
+        in {
+          inherit tl;
+
+          xelatex = builder "xelatex";
+          lualatex = builder "lualatex";
+          pdflatex = builder "pdflatex";
+
+          zip = stdenvNoCC.mkDerivation {
+            pname = "listlbls";
+            inherit version;
+
+            src = "${self}";
+
+            nativeBuildInputs = [pkgs.zip tl];
+
+            makeFlags = ["zip" "VERS=$(version)"];
+
+            installPhase = ''
+              mkdir $out
+              install --mode 444 $pname-$version.zip $out/$pname-$version.zip
+            '';
+          };
         };
-    in {
-      inherit tl;
 
-      xelatex = builder "xelatex";
-      lualatex = builder "lualatex";
-      pdflatex = builder "pdflatex";
-
-      zip = stdenvNoCC.mkDerivation {
-        pname = "listlbls";
-        inherit version;
-
-        src = "${self}";
-
-        nativeBuildInputs = [pkgs.zip tl];
-
-        makeFlags = ["zip" "VERS=$(version)"];
-
-        installPhase = ''
-          mkdir $out
-          install --mode 444 $pname-$version.zip $out/$pname-$version.zip
-        '';
+        devShells.default = let
+          inherit (self'.packages) tl;
+        in
+          pkgs.mkShellNoCC {
+            packages = builtins.attrValues {
+              inherit (pkgs) gnumake;
+              inherit tl;
+            };
+          };
       };
     };
-
-    devShells.x86_64-linux.default = let
-      pkgs = nixpkgs.legacyPackages.x86_64-linux;
-      inherit (self.packages.x86_64-linux) tl;
-    in
-      pkgs.mkShellNoCC {
-        packages = builtins.attrValues {
-          inherit (pkgs) gnumake;
-          inherit tl;
-        };
-      };
-  };
 }

--- a/listlbls.dtx
+++ b/listlbls.dtx
@@ -125,7 +125,7 @@ Running "make install" installs the files in the local TeX tree.
 %<*driver>
 \documentclass{ltxdoc}
 \usepackage{microtype}
-\usepackage{libertine}
+\usepackage{lmodern}
 \usepackage[a4paper,margin=25mm,left=50mm,nohead]{geometry}
 \usepackage{multicol}
 \usepackage{doc}
@@ -163,6 +163,7 @@ Running "make install" installs the files in the local TeX tree.
 %\changes{v1.02}{2014/07/27}{Added languag-support for English, German and French.}
 %\changes{v1.03}{2014/08/04}{Proceeding with namespacing internal macros}
 %\changes{v1.04}{20xx/xx/xx}{Fix build problems due to bitrotten dependencies}
+%\changes{v1.04}{20xx/xx/xx}{Switch back to lmodern for documentation}
 % \begin{abstract}
 % This is a package meant to help a \LaTeX-writer to keep track all the defined labels by typesetting a complete list of labels whereever the author requests it. Keep in mind, that you might need to have additional \LaTeX\ runs to get the references right.
 %

--- a/listlbls.dtx
+++ b/listlbls.dtx
@@ -190,7 +190,9 @@ Running "make install" installs the files in the local TeX tree.
 %
 % \begin{enumerate}
 %   \item Check out the sourcecode from \link{https://github.com/}{GitHub}:\\
-%     |git clone git@github.com:NobbZ/listlbls.git|
+%     |git clone https://github.com/NobbZ/nixos-config.git| or\\
+%     |git clone git@github.com:NobbZ/listlbls.git| or\\
+%     |gh repo clone NobbZ/listlbls|
 %   \item Switch to the source-folder:\\|cd listlbls|
 %   \item Checkout the branch/tag you desire: |master| for latest release, |develop| for latest builds (might be broken) or the version number desired.\\
 %     |git checkout <branch/tag>|

--- a/listlbls.dtx
+++ b/listlbls.dtx
@@ -129,7 +129,7 @@ Running "make install" installs the files in the local TeX tree.
 \usepackage{fontawesome5}
 \usepackage[a4paper,margin=25mm,left=50mm,nohead]{geometry}
 \usepackage{multicol}
-\usepackage{doc}
+\usepackage[reportchangedates]{doc}
 \usepackage{dtxdescribe}
 \usepackage[numbered]{hypdoc}
 \usepackage{xspace}
@@ -488,8 +488,9 @@ Running "make install" installs the files in the local TeX tree.
 %    \begin{macrocode}
 \ifllbls@draft
 %    \end{macrocode}
-% \begin{macro}{\listoflabels}\begin{macro}{\llbls@labelname}
+% \begin{macro}{\listoflabels}
 % \changes{v1.04}{20xx/xx/xx}{add optional argument to change the name of the label used.}
+% \begin{macro}{\llbls@labelname}
 % Print a list of all available lables that are defined throughout the document.
 %    \begin{macrocode}
   \newcommand{\listoflabels}[1][special:listoflabels]{%

--- a/listlbls.dtx
+++ b/listlbls.dtx
@@ -269,6 +269,17 @@ Running "make install" installs the files in the local TeX tree.
 %   \item and wait for approval.
 % \end{enumerate}
 % After approval your code will be merged to the |development|-branch and I will generally not accept pull-requests that edit |develop| directly.
+%
+% \section{Known issues and limitations}\label{sec:issues}
+% \changes{v1.04}{20xx/xx/xx}{Add issues and limitations section}
+%
+% \subsection{include}\label{ssec:issues-include}
+% 
+% Documents containing |\include| will not work.
+% Currently there is no logic to recurse through the different |.aux|-files.
+%
+% Please see \href{https://github.com/NobbZ/listlbls/issues/4}{issue \#4} for more information.
+%
 % \section{Implementation}\label{sec:implementation}
 %
 %    \begin{macrocode}

--- a/listlbls.dtx
+++ b/listlbls.dtx
@@ -240,7 +240,8 @@ Running "make install" installs the files in the local TeX tree.
 %
 % Then anywhere in your document, you can use the |\listoflabels|-macro to typeset a list of labels. An example can be seen on page \pageref{special:listoflabels}.
 %
-% \DescribeMacro{\label} Use |\label| as you are used to it!
+% \DescribeMacro{\label} \marg{name}
+% Use |\label| as you are used to it!
 %
 % \DescribeMacro{\listoflabels} This macro will typeset the list of labels when this module is in draft mode. It will itself register the label ``|special:listoflabels|''.
 %
@@ -367,6 +368,16 @@ Running "make install" installs the files in the local TeX tree.
 \DeclareTranslation{French}%
   {llbls-onpage}%
   {\`a la page}
+%    \end{macrocode}
+% \subsubsection{Portuguese}\label{sssec:impl-i18n-pt}
+% \changes{v1.04}{20xx/xx/xx}{Add Portuguese translation}
+%    \begin{macrocode}
+\DeclareTranslation{Portuguese}%
+  {llbls-listoflabels}%
+  {Lista de R\'{o}tulos}
+\DeclareTranslation{Portuguese}%
+  {llbls-onpage}%
+  {na p\'{a}gina}
 %    \end{macrocode}
 % \subsection{Internal stuff}\label{ssec:impl-internal}
 % \begin{macro}{\llbls@headline}\begin{macro}{\llbls@toccommand}\begin{macro}{\llbls@tocgroup}

--- a/listlbls.dtx
+++ b/listlbls.dtx
@@ -127,10 +127,9 @@ Running "make install" installs the files in the local TeX tree.
 \usepackage{microtype}
 \usepackage{libertine}
 \usepackage[a4paper,margin=25mm,left=50mm,nohead]{geometry}
-\usepackage{colordoc}
 \usepackage{multicol}
-\usepackage{dox}
-\doxitem{Option}{option}{option}
+\usepackage{doc}
+\usepackage{dtxdescribe}
 \usepackage[numbered]{hypdoc}
 \usepackage{xspace}
 \usepackage{nameref}
@@ -163,6 +162,7 @@ Running "make install" installs the files in the local TeX tree.
 %\changes{v1.02}{2014/07/26}{Local option wins agains global option}
 %\changes{v1.02}{2014/07/27}{Added languag-support for English, German and French.}
 %\changes{v1.03}{2014/08/04}{Proceeding with namespacing internal macros}
+%\changes{v1.04}{20xx/xx/xx}{Fix build problems due to bitrotten dependencies}
 % \begin{abstract}
 % This is a package meant to help a \LaTeX-writer to keep track all the defined labels by typesetting a complete list of labels whereever the author requests it. Keep in mind, that you might need to have additional \LaTeX\ runs to get the references right.
 %

--- a/listlbls.dtx
+++ b/listlbls.dtx
@@ -127,7 +127,7 @@ Running "make install" installs the files in the local TeX tree.
 \usepackage{microtype}
 \usepackage{lmodern}
 \usepackage{fontawesome5}
-\usepackage[a4paper,margin=25mm,left=50mm,nohead]{geometry}
+\usepackage[a4paper,margin=25mm,left=45mm,nohead]{geometry}
 \usepackage{multicol}
 \usepackage[reportchangedates]{doc}
 \usepackage{dtxdescribe}

--- a/listlbls.dtx
+++ b/listlbls.dtx
@@ -120,7 +120,7 @@ Running "make install" installs the files in the local TeX tree.
 %<package>\NeedsTeXFormat{LaTeX2e}[1999/12/01]
 %<package>\ProvidesPackage{listlbls}
 %<*package>
-    [2014/08/04 v1.03 Creates a list of all labels used throughout a document]
+    [2000/00/00 v1.04pre Creates a list of all labels used throughout a document]
 %</package>
 %<*driver>
 \documentclass{ltxdoc}
@@ -244,7 +244,9 @@ Running "make install" installs the files in the local TeX tree.
 % \DescribeMacro{\label} \marg{name}
 % Use |\label| as you are used to it!
 %
-% \DescribeMacro{\listoflabels} This macro will typeset the list of labels when this module is in draft mode. It will itself register the label ``|special:listoflabels|''.
+% \DescribeMacro{\listoflabels} \oarg{label}
+% This macro will typeset the list of labels when this module is in draft mode.
+% It will itself register the label from the optional arg, defaulting to ``|special:listoflabels|''.
 %
 %\StopEventually{^^A
 %  \PrintChanges
@@ -398,7 +400,10 @@ Running "make install" installs the files in the local TeX tree.
 \ifdefined\chapter
   \ifllbls@numtoc
     \def\llbls@headline{%
-      \chapter{List of Labels}\label{special:listoflabels}}
+%    \end{macrocode}
+% We are using |\llbls@labelname| here and in the other possible definitions of |\llbls@headline| to be able to set the label name in the |\listoflabels| macro.
+%    \begin{macrocode}
+      \chapter{List of Labels}\label{\llbls@labelname}}
   \else
     \def\llbls@toccommand{\chapter*}
     \def\llbls@tocgroup{chapter}
@@ -406,7 +411,7 @@ Running "make install" installs the files in the local TeX tree.
 \else
   \ifllbls@numtoc
     \def\llbls@headline{%
-      \section{List of Labels}\label{special:listoflabels}}
+      \section{List of Labels}\label{\llbls@labelname}}
   \else
     \def\llbls@toccommand{\section*}
     \def\llbls@tocgroup{section}
@@ -415,7 +420,7 @@ Running "make install" installs the files in the local TeX tree.
 \ifdefined\llbls@headline\else
   \def\llbls@headline{%
     \llbls@toccommand{\GetTranslation{llbls-listoflabels}}%
-    \label{special:listoflabels}%
+    \label{\llbls@labelname}%
     \ifllbls@totoc%
       \addcontentsline{toc}%
         {\llbls@tocgroup}%
@@ -476,14 +481,16 @@ Running "make install" installs the files in the local TeX tree.
 %    \begin{macrocode}
 \ifllbls@draft
 %    \end{macrocode}
-% \begin{macro}{\listoflabels}
+% \begin{macro}{\listoflabels}\begin{macro}{\llbls@labelname}
+% \changes{v1.04}{20xx/xx/xx}{add optional argument to change the name of the label used.}
 % Print a list of all available lables that are defined throughout the document.
 %    \begin{macrocode}
-  \newcommand\listoflabels{%
+  \newcommand{\listoflabels}[1][special:listoflabels]{%
+    \def\llbls@labelname{#1}%
     \llbls@headline%
     \the\llbls@lablist}
 %    \end{macrocode}
-% \end{macro}
+% \end{macro}\end{macro}
 %    \begin{macrocode}
 \else
   \let\listoflabels=\relax

--- a/listlbls.dtx
+++ b/listlbls.dtx
@@ -372,7 +372,7 @@ Running "make install" installs the files in the local TeX tree.
 % \begin{macro}{\llbls@headline}\begin{macro}{\llbls@toccommand}\begin{macro}{\llbls@tocgroup}
 % Determine if we have |\chapter|s or not and create a command that maps to |\chapter| or |\section| as needed.
 %    \begin{macrocode}
-\ifdefined\chapter*
+\ifdefined\chapter
   \ifllbls@numtoc
     \def\llbls@headline{%
       \chapter{List of Labels}\label{special:listoflabels}}

--- a/listlbls.dtx
+++ b/listlbls.dtx
@@ -164,7 +164,7 @@ Running "make install" installs the files in the local TeX tree.
 %\changes{v1.00}{2014/07/25}{First public release}
 %\changes{v1.01}{2014/07/25}{Changed maintainer email}
 %\changes{v1.01}{2014/07/25}{Changed some internal stuff to make it releaseable on CTAN}
-%\changes{v1.02}{2014/07/26}{Local option wins agains global option}
+%\changes{v1.02}{2014/07/27}{Local option wins agains global option}
 %\changes{v1.02}{2014/07/27}{Added languag-support for English, German and French.}
 %\changes{v1.03}{2014/08/04}{Proceeding with namespacing internal macros}
 %\changes{v1.04}{20xx/xx/xx}{Fix build problems due to bitrotten dependencies}
@@ -302,7 +302,7 @@ Running "make install" installs the files in the local TeX tree.
 % \subsection{Options}\label{ssec:impl-options}
 % \begin{option}{draft}
 % \changes{v1.01}{2014/07/25}{Added option}
-% \changes{v1.02}{2014/07/26}{Introduced @ifdraft}
+% \changes{v1.02}{2014/07/27}{Introduced @ifdraft}
 % Check for |draft|-option:
 %    \begin{macrocode}
 \DeclareOption{draft}{\llbls@drafttrue}
@@ -310,21 +310,21 @@ Running "make install" installs the files in the local TeX tree.
 % \end{option}
 % \begin{option}{final}
 % \changes{v1.01}{2014/07/25}{Added option}
-% \changes{v1.02}{2014/07/26}{Introduced @ifdraft}
+% \changes{v1.02}{2014/07/27}{Introduced @ifdraft}
 % Check for |final|-option:
 %    \begin{macrocode}
 \DeclareOption{final}{\llbls@draftfalse}
 %    \end{macrocode}
 % \end{option}
 % \begin{option}{totoc}
-% \changes{v1.02}{2014/07/26}{Added option}
+% \changes{v1.02}{2014/07/27}{Added option}
 % Check for |totoc|-option:
 %    \begin{macrocode}
 \DeclareOption{totoc}{\llbls@totoctrue}
 %    \end{macrocode}
 % \end{option}
 % \begin{option}{notoc}
-% \changes{v1.02}{2014/07/26}{Added option}
+% \changes{v1.02}{2014/07/27}{Added option}
 % Check for |notoc|-option:
 %    \begin{macrocode}
 \DeclareOption{notoc}{\llbls@totocfalse}
@@ -463,7 +463,7 @@ Running "make install" installs the files in the local TeX tree.
 % \end{macro}
 %
 % \begin{macro}{\llbls@showlabel}
-% \changes{v1.03}{2014/07/27}{Add support for nameref-package}
+% \changes{v1.02}{2014/08/04}{Add support for nameref-package}
 % Displays a single entry in the |\listoflabels|
 %    \begin{macrocode}
 \def\llbls@showlabel#1#2{%

--- a/listlbls.dtx
+++ b/listlbls.dtx
@@ -126,6 +126,7 @@ Running "make install" installs the files in the local TeX tree.
 \documentclass{ltxdoc}
 \usepackage{microtype}
 \usepackage{lmodern}
+\usepackage{fontawesome5}
 \usepackage[a4paper,margin=25mm,left=50mm,nohead]{geometry}
 \usepackage{multicol}
 \usepackage{doc}
@@ -139,6 +140,10 @@ Running "make install" installs the files in the local TeX tree.
 \CodelineIndex
 \RecordChanges
 \newcommand\TSE{\href{http://tex.stackexchange.com/}{\TeX-Stackexchange}\xspace}
+
+\newcommand\link[2]{\href{#1}{#2}\footnote{\nolinkurl{#1}}}
+\newcommand\ghissue[3]{\link{https://github.com/#1/#2/issues/#3}{\faIcon{github}~#1/#2\##3}}
+\newcommand\thisissue[1]{\ghissue{nobbz}{listlbls}{#1}}
 \begin{document}
   \DocInput{\jobname.dtx}
 \end{document}
@@ -184,7 +189,7 @@ Running "make install" installs the files in the local TeX tree.
 % \subsection{From Github}\label{ssec:inst-gh}
 %
 % \begin{enumerate}
-%   \item Check out the sourcecode from \href{https://github.com/}{GitHub}:\\
+%   \item Check out the sourcecode from \link{https://github.com/}{GitHub}:\\
 %     |git clone git@github.com:NobbZ/listlbls.git|
 %   \item Switch to the source-folder:\\|cd listlbls|
 %   \item Checkout the branch/tag you desire: |master| for latest release, |develop| for latest builds (might be broken) or the version number desired.\\
@@ -258,11 +263,11 @@ Running "make install" installs the files in the local TeX tree.
 %
 % \section{Contribution and bugreports}\label{sec:contribute}
 %
-% If you have feature-requests or bug-reports, please feel free to report them on the \href{https://github.com/NobbZ/listlbls}{project page at GitHub}.
+% If you have feature-requests or bug-reports, please feel free to report them on the \link{https://github.com/NobbZ/listlbls}{project page at GitHub}.
 %
 % If you want to contribute then follow these steps:
 % \begin{enumerate}
-%   \item Visit the \href{https://github.com/NobbZ/listlbls}{project page at GitHub},
+%   \item Visit the \link{https://github.com/NobbZ/listlbls}{project page at GitHub},
 %   \item forkt it,
 %   \item clone it to your local machine,
 %   \item create a branch ``|feature/|\meta{feature name}'',
@@ -276,12 +281,12 @@ Running "make install" installs the files in the local TeX tree.
 % \section{Known issues and limitations}\label{sec:issues}
 % \changes{v1.04}{20xx/xx/xx}{Add issues and limitations section}
 %
-% \subsection{include}\label{ssec:issues-include}
+% \subsection{\texttt{\textbackslash{}include}}\label{ssec:issues-include}
 % 
 % Documents containing |\include| will not work.
 % Currently there is no logic to recurse through the different |.aux|-files.
 %
-% Please see \href{https://github.com/NobbZ/listlbls/issues/4}{issue \#4} for more information.
+% Please see \thisissue{4} for more information.
 %
 % \section{Implementation}\label{sec:implementation}
 %

--- a/listlbls.dtx
+++ b/listlbls.dtx
@@ -120,7 +120,7 @@ Running "make install" installs the files in the local TeX tree.
 %<package>\NeedsTeXFormat{LaTeX2e}[1999/12/01]
 %<package>\ProvidesPackage{listlbls}
 %<*package>
-    [2000/00/00 v1.04pre Creates a list of all labels used throughout a document]
+    [2023/05/24 v1.04 Creates a list of all labels used throughout a document]
 %</package>
 %<*driver>
 \documentclass{ltxdoc}
@@ -167,8 +167,8 @@ Running "make install" installs the files in the local TeX tree.
 %\changes{v1.02}{2014/07/27}{Local option wins agains global option}
 %\changes{v1.02}{2014/07/27}{Added languag-support for English, German and French.}
 %\changes{v1.03}{2014/08/04}{Proceeding with namespacing internal macros}
-%\changes{v1.04}{20xx/xx/xx}{Fix build problems due to bitrotten dependencies}
-%\changes{v1.04}{20xx/xx/xx}{Switch back to lmodern for documentation}
+%\changes{v1.04}{2023/05/24}{Fix build problems due to bitrotten dependencies}
+%\changes{v1.04}{2023/05/24}{Switch back to lmodern for documentation}
 % \begin{abstract}
 % This is a package meant to help a \LaTeX-writer to keep track all the defined labels by typesetting a complete list of labels whereever the author requests it. Keep in mind, that you might need to have additional \LaTeX\ runs to get the references right.
 %
@@ -281,7 +281,7 @@ Running "make install" installs the files in the local TeX tree.
 % After approval your code will be merged to the |development|-branch and I will generally not accept pull-requests that edit |develop| directly.
 %
 % \section{Known issues and limitations}\label{sec:issues}
-% \changes{v1.04}{20xx/xx/xx}{Add issues and limitations section}
+% \changes{v1.04}{2023/05/24}{Add issues and limitations section}
 %
 % \subsection{\texttt{\textbackslash{}include}}\label{ssec:issues-include}
 % 
@@ -391,7 +391,7 @@ Running "make install" installs the files in the local TeX tree.
   {\`a la page}
 %    \end{macrocode}
 % \subsubsection{Portuguese}\label{sssec:impl-i18n-pt}
-% \changes{v1.04}{20xx/xx/xx}{Add Portuguese translation}
+% \changes{v1.04}{2023/05/24}{Add Portuguese translation}
 %    \begin{macrocode}
 \DeclareTranslation{Portuguese}%
   {llbls-listoflabels}%
@@ -489,7 +489,7 @@ Running "make install" installs the files in the local TeX tree.
 \ifllbls@draft
 %    \end{macrocode}
 % \begin{macro}{\listoflabels}
-% \changes{v1.04}{20xx/xx/xx}{add optional argument to change the name of the label used.}
+% \changes{v1.04}{2023/05/24}{add optional argument to change the name of the label used.}
 % \begin{macro}{\llbls@labelname}
 % Print a list of all available lables that are defined throughout the document.
 %    \begin{macrocode}

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -15,6 +15,7 @@
         dtxdescribe
         etoolbox
         fancyvrb
+        fontawesome5
         geometry
         graphics
         hypdoc

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -1,0 +1,80 @@
+{self, ...}: {
+  perSystem = {
+    pkgs,
+    self',
+    ...
+  }: let
+    version = "1.04pre";
+    texCombined = pkgs.texlive.combine {
+      inherit
+        (pkgs.texlive)
+        scheme-minimal
+        collection-luatex
+        babel-english
+        caption
+        dtxdescribe
+        etoolbox
+        fancyvrb
+        geometry
+        graphics
+        hypdoc
+        hyperref
+        infwarerr
+        kvoptions
+        latex-bin
+        microtype
+        newfloat
+        pdftexcmds
+        pict2e
+        tools
+        translations
+        xcolor
+        xetex
+        xstring
+        ;
+    };
+    inherit (pkgs) stdenvNoCC;
+    builder = engine:
+      stdenvNoCC.mkDerivation {
+        pname = "listllbls";
+        version = "${version}-${engine}";
+
+        src = "${self}";
+
+        nativeBuildInputs = [texCombined];
+
+        makeFlags = ["PREFIX=$(out)" "LATEX=${engine}" "SUDO="];
+
+        configurePhase = ''
+          export TEMP=$(pwd)
+          export HOME=$(pwd)
+        '';
+      };
+  in {
+    packages = {
+      inherit texCombined;
+
+      xelatex = builder "xelatex";
+      lualatex = builder "lualatex";
+      pdflatex = builder "pdflatex";
+
+      default = self'.packages.xelatex;
+
+      zip = stdenvNoCC.mkDerivation {
+        pname = "listlbls";
+        inherit version;
+
+        src = "${self}";
+
+        nativeBuildInputs = [pkgs.zip texCombined];
+
+        makeFlags = ["zip" "VERS=$(version)"];
+
+        installPhase = ''
+          mkdir $out
+          install --mode 444 $pname-$version.zip $out/$pname-$version.zip
+        '';
+      };
+    };
+  };
+}

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -37,7 +37,7 @@
     inherit (pkgs) stdenvNoCC;
     builder = engine:
       stdenvNoCC.mkDerivation {
-        pname = "listllbls";
+        pname = "listlbls";
         version = "${version}-${engine}";
 
         src = "${self}";

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -4,7 +4,7 @@
     self',
     ...
   }: let
-    version = "1.04pre";
+    version = "1.04";
     texCombined = pkgs.texlive.combine {
       inherit
         (pkgs.texlive)


### PR DESCRIPTION
- remove asterisk from macro check
- feature: add portuguese translation
- doc: add 'issues' section
- chore: flake
- fix: make buildable with modern TeXlive again
- chore: make Makefile more verbose
- chore: use lmodern
- refactor: use flake parts
- refactor: extract packages into own module
- feature: add optional argument to listoflabels that controls the labelname
- docs: change how most links are displayed
- chore: make Makefile verbose again
- doc: document different ways to clone
- fix name in derivation
- fix index entry in changelog
- adjust page geometry for the documentation
- ci: initial workflow
- ci: copy ZIP into build root
- ci: more verbose output
- ci: hold PDF and STY artifacts
- chore: prepare nix expressions
- chore: fix old release dates
- chore: bump version to 1.04
